### PR TITLE
calibratable_parameters 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ _________________________________________________________________
 | soil_storage_model | string | conceptual or layered or topmodel | - | - | if `conceptual`, conceptual models are used for computing the soil moisture profile (e.g., CFE). If `layered`, layered-based soil moisture models are used (e.g., LGAR). If `topmodel`, topmodel's variables are used
 | soil_moisture_profile_option | string | constant or linear | - | - | `constant` for layered-constant profile. `linear`  for linearly interpolated values between two consecutive layers. Needed if `soil_storage_model = layered`.
 | soil_depth_layers | double (1D array) | - | - | - | Absolute depth of soil layers. Needed if `soil_storage_model = layered`.
-| max_num_wetting_fronts | int | - | - | - | Maximum number of wetting fronts. Default is set to 30. Needed if `soil_storage_model = layered`.
 | soil_moisture_fraction_depth | double | (0, domain_depth] | m | - | *user specified depth for the soil moisture fraction (default is 40 cm)
 | water_table_based_method | string | flux-based or deficit-based | - | - | Needed if `soil_storage_model = topmodel`. `flux-based` uses an iterative scheme, and `deficit-based` uses catchment deficit to compute soil moisture profile
 

--- a/include/bmi_soil_moisture_profile.hxx
+++ b/include/bmi_soil_moisture_profile.hxx
@@ -21,9 +21,9 @@ public:
   BmiSoilMoistureProfile() {
     this->input_var_names[0]  = "soil_storage";
     this->input_var_names[1]  = "soil_storage_change";
-    this->input_var_names[2]  = "soil_moisture_wetting_fronts";
-    this->input_var_names[3]  = "soil_depth_wetting_fronts";
-    this->input_var_names[4]  = "num_wetting_fronts";
+    this->input_var_names[2]  = "num_wetting_fronts";
+    this->input_var_names[3]  = "soil_moisture_wetting_fronts";
+    this->input_var_names[4]  = "soil_depth_wetting_fronts";
     this->input_var_names[5]  = "Qb_topmodel";        // baseflow in the topmodel
     this->input_var_names[6]  = "Qv_topmodel";        // recharge rate to the saturated zone to the un saturated zone
                                                      // in the topmodel

--- a/include/bmi_soil_moisture_profile.hxx
+++ b/include/bmi_soil_moisture_profile.hxx
@@ -27,7 +27,7 @@ public:
     this->input_var_names[5]  = "Qb_topmodel";        // baseflow in the topmodel
     this->input_var_names[6]  = "Qv_topmodel";        // recharge rate to the saturated zone to the un saturated zone
                                                      // in the topmodel
-    this->input_var_names[7]  = "global_deficit";     // global soil deficit in the topmodel
+    this->input_var_names[7]  = "global_deficit";    // global soil deficit in the topmodel
     
     this->output_var_names[0] = "soil_moisture_profile";  // entire profile of the soil column (1D array)
     this->output_var_names[1] = "soil_water_table";       // depth of the water table from the surface in meters
@@ -92,6 +92,8 @@ public:
   void GetGridFaceEdges(const int grid, int *face_edges);
   void GetGridFaceNodes(const int grid, int *face_nodes);
   void GetGridNodesPerFace(const int grid, int *nodes_per_face);
+  void ResetSize (std::string name);
+  
 private:
   soil_moisture_profile::soil_profile_parameters* state;
   static const int input_var_name_count  = 8;

--- a/include/bmi_soil_moisture_profile.hxx
+++ b/include/bmi_soil_moisture_profile.hxx
@@ -19,19 +19,24 @@ namespace coupler {
 class BmiSoilMoistureProfile : public bmixx::Bmi {
 public:
   BmiSoilMoistureProfile() {
-    this->input_var_names[0] = "soil_storage";
-    this->input_var_names[1] = "soil_storage_change";
-    this->input_var_names[2] = "soil_moisture_wetting_fronts";
-    this->input_var_names[3] = "soil_depth_wetting_fronts";
-    this->input_var_names[4] = "num_wetting_fronts";
-    this->input_var_names[5] = "Qb_topmodel";        // baseflow in the topmodel
-    this->input_var_names[6] = "Qv_topmodel";        // recharge rate to the saturated zone to the un saturated zone
+    this->input_var_names[0]  = "soil_storage";
+    this->input_var_names[1]  = "soil_storage_change";
+    this->input_var_names[2]  = "soil_moisture_wetting_fronts";
+    this->input_var_names[3]  = "soil_depth_wetting_fronts";
+    this->input_var_names[4]  = "num_wetting_fronts";
+    this->input_var_names[5]  = "Qb_topmodel";        // baseflow in the topmodel
+    this->input_var_names[6]  = "Qv_topmodel";        // recharge rate to the saturated zone to the un saturated zone
                                                      // in the topmodel
-    this->input_var_names[7] = "global_deficit";     // global soil deficit in the topmodel
+    this->input_var_names[7]  = "global_deficit";     // global soil deficit in the topmodel
     
     this->output_var_names[0] = "soil_moisture_profile";  // entire profile of the soil column (1D array)
     this->output_var_names[1] = "soil_water_table";       // depth of the water table from the surface in meters
     this->output_var_names[2] = "soil_moisture_fraction"; // fraction of soil moisture, top 0.4 m (or user specified depth)
+
+    // add calibratable parameters
+    this->calib_var_names[0]  = "smcmax";
+    this->calib_var_names[1]  = "b";
+    this->calib_var_names[2]  = "satpsi";
   };
   
   void Initialize(std::string config_file);
@@ -91,9 +96,11 @@ private:
   soil_moisture_profile::soil_profile_parameters* state;
   static const int input_var_name_count  = 8;
   static const int output_var_name_count = 3;
+  static const int calib_var_name_count  = 3;
   
   std::string input_var_names[input_var_name_count];
   std::string output_var_names[output_var_name_count];
+  std::string calib_var_names[calib_var_name_count];
   std::string verbosity;
 };
 

--- a/include/soil_moisture_profile.hxx
+++ b/include/soil_moisture_profile.hxx
@@ -18,7 +18,7 @@
   @param soil_moisture_wetting_fronts  [-] : soil moisture content of wetting fronts (bmi input to layered the model)
   @param soil_depth_wetting_fronts     [m] : absolute depth of the wetting fronts (bmi input to layered the model)
   @param smcmax                    [-] : maximum soil moisture content (porosity)
-  @param bb                        [-] : pore size distribution, beta exponent in Clapp-Hornberger (1978) function
+  @param b                         [-] : pore size distribution, beta exponent in Clapp-Hornberger (1978) function
   @param satpsi                    [m] : saturated capillary head (saturated moisture potential)
   @param ncells                    [-] : number of cells of the discretized soil column
   @param nlayers                   [-] : number of soil moisture layers, typically different than the ncells
@@ -75,7 +75,7 @@ namespace soil_moisture_profile {
     double *soil_moisture_profile;
     
     double *smcmax;
-    double bb;
+    double b;
     double satpsi;
     int    ncells;
     double soil_depth;

--- a/src/bmi_soil_moisture_profile.cxx
+++ b/src/bmi_soil_moisture_profile.cxx
@@ -62,9 +62,9 @@ GetVarGrid(std::string name)
     return 1;
   else if (name.compare("Qb_topmodel") == 0 || name.compare("Qv_topmodel") == 0 || name.compare("global_deficit") == 0)
     return 1;
-  else if (name.compare("smcmax") == 0 || name.compare("b") == 0 || name.compare("satpsi") == 0)
+  else if (name.compare("b") == 0 || name.compare("satpsi") == 0)
     return 1;
-  else if (name.compare("soil_moisture_profile") == 0) // array of doubles (conceptual model)
+  else if (name.compare("soil_moisture_profile") == 0 || name.compare("smcmax") == 0) // array of doubles (conceptual model)
     return 2;
   else if (name.compare("soil_moisture_wetting_fronts") == 0 || name.compare("soil_depth_wetting_fronts") == 0) // array of doubles (layered model)
     return 3; 
@@ -329,7 +329,7 @@ GetValuePtr (std::string name)
   else if (name.compare("global_deficit") == 0)
     return (void*)(&this->state->global_deficit);
   else if (name.compare("smcmax") == 0)
-    return (void*)(this->state->smcmax);
+    return (void*)this->state->smcmax;
   else if (name.compare("b") == 0)
     return (void*)(&this->state->b);
   else if (name.compare("satpsi") == 0)

--- a/src/bmi_soil_moisture_profile.cxx
+++ b/src/bmi_soil_moisture_profile.cxx
@@ -310,10 +310,14 @@ GetValuePtr (std::string name)
     return (void*)(&this->state->soil_moisture_fraction);
   else if (name.compare("soil_moisture_profile") == 0)
     return (void*)this->state->soil_moisture_profile;
-  else if (name.compare("soil_moisture_wetting_fronts") == 0)
+  else if (name.compare("soil_moisture_wetting_fronts") == 0) {
+    state->soil_moisture_wetting_fronts = new double[this->state->num_wetting_fronts];
     return (void*)this->state->soil_moisture_wetting_fronts;
-  else if (name.compare("soil_depth_wetting_fronts") == 0)
+  }
+  else if (name.compare("soil_depth_wetting_fronts") == 0) {
+    state->soil_depth_wetting_fronts = new double[this->state->num_wetting_fronts];
     return (void*)this->state->soil_depth_wetting_fronts;
+  }
   else if (name.compare("soil_storage_model") == 0)
     return (void*)(&this->state->soil_storage_model);
   else if (name.compare("num_wetting_fronts") == 0)
@@ -372,6 +376,10 @@ SetValue (std::string name, void *src)
     int nbytes = 0;
     nbytes = this->GetVarNbytes(name);
     memcpy(dest, src, nbytes);
+    
+    if (name.compare("num_wetting_fronts") == 0)
+      this->state->shape[1] = this->state->num_wetting_fronts;
+    
   }
 
 }

--- a/src/bmi_soil_moisture_profile.cxx
+++ b/src/bmi_soil_moisture_profile.cxx
@@ -62,6 +62,8 @@ GetVarGrid(std::string name)
     return 1;
   else if (name.compare("Qb_topmodel") == 0 || name.compare("Qv_topmodel") == 0 || name.compare("global_deficit") == 0)
     return 1;
+  else if (name.compare("smcmax") == 0 || name.compare("b") == 0 || name.compare("satpsi") == 0)
+    return 1;
   else if (name.compare("soil_moisture_profile") == 0) // array of doubles (conceptual model)
     return 2;
   else if (name.compare("soil_moisture_wetting_fronts") == 0 || name.compare("soil_depth_wetting_fronts") == 0) // array of doubles (layered model)
@@ -322,6 +324,12 @@ GetValuePtr (std::string name)
     return (void*)(&this->state->Qv_topmodel);
   else if (name.compare("global_deficit") == 0)
     return (void*)(&this->state->global_deficit);
+  else if (name.compare("smcmax") == 0)
+    return (void*)(&this->state->smcmax);
+  else if (name.compare("b") == 0)
+    return (void*)(&this->state->b);
+  else if (name.compare("satpsi") == 0)
+    return (void*)(&this->state->satpsi);
   else {
     std::stringstream errMsg;
     errMsg << "variable "<< name << " does not exist";

--- a/src/bmi_soil_moisture_profile.cxx
+++ b/src/bmi_soil_moisture_profile.cxx
@@ -325,7 +325,7 @@ GetValuePtr (std::string name)
   else if (name.compare("global_deficit") == 0)
     return (void*)(&this->state->global_deficit);
   else if (name.compare("smcmax") == 0)
-    return (void*)(&this->state->smcmax);
+    return (void*)(this->state->smcmax);
   else if (name.compare("b") == 0)
     return (void*)(&this->state->b);
   else if (name.compare("satpsi") == 0)

--- a/src/soil_moisture_profile.cxx
+++ b/src/soil_moisture_profile.cxx
@@ -31,8 +31,8 @@ SoilMoistureProfile(string config_file, struct soil_profile_parameters* paramete
 
   parameters->soil_moisture_profile = new double[parameters->ncells];
 
-  parameters->soil_moisture_wetting_fronts = new double[parameters->shape[1]];
-  parameters->soil_depth_wetting_fronts    = new double[parameters->shape[1]];
+  parameters->soil_moisture_wetting_fronts = new double[parameters->shape[1]]();
+  parameters->soil_depth_wetting_fronts    = new double[parameters->shape[1]]();
 
   // For water_table_based_method
   parameters->cat_area     = 1.0;        // catchment area used in the topmodel (normalized)
@@ -43,8 +43,8 @@ SoilMoistureProfile(string config_file, struct soil_profile_parameters* paramete
   parameters->origin[1]    = 0.;
   parameters->soil_storage = 0.0;
   parameters->init_profile = true;
-  //parameters->num_wetting_fronts = 1;
   parameters->soil_depth_NWM = 2.0;
+  parameters->num_wetting_fronts = parameters->shape[1];
   parameters->soil_storage_change_per_timestep = 0.0;
 }
 
@@ -327,6 +327,7 @@ SoilMoistureProfileUpdate(struct soil_profile_parameters* parameters)
   double thickness = 0.0;
   double soil_moisture_fraction_depth = parameters->soil_moisture_fraction_depth;
   parameters->soil_moisture_fraction = 0.0; // reset to 0 at each timestep
+  
   
   if (parameters->soil_storage_model == Conceptual) {
     SoilMoistureProfileFromConceptualReservoir(parameters);

--- a/src/soil_moisture_profile.cxx
+++ b/src/soil_moisture_profile.cxx
@@ -27,7 +27,7 @@ SoilMoistureProfile(string config_file, struct soil_profile_parameters* paramete
   if (parameters->soil_storage_model == Conceptual || parameters->soil_storage_model == Topmodel)
     parameters->shape[1] = 1;
   else if (parameters->soil_storage_model == Layered)
-    parameters->shape[1] = parameters->max_num_wetting_fronts;
+    parameters->shape[1] = parameters->num_wetting_fronts;
 
   parameters->soil_moisture_profile = new double[parameters->ncells];
 
@@ -43,7 +43,7 @@ SoilMoistureProfile(string config_file, struct soil_profile_parameters* paramete
   parameters->origin[1]    = 0.;
   parameters->soil_storage = 0.0;
   parameters->init_profile = true;
-  parameters->num_wetting_fronts = 1;
+  //parameters->num_wetting_fronts = 1;
   parameters->soil_depth_NWM = 2.0;
   parameters->soil_storage_change_per_timestep = 0.0;
 }
@@ -88,7 +88,6 @@ InitFromConfigFile(string config_file, struct soil_profile_parameters* parameter
   bool is_satpsi_set                    = false;
   bool is_soil_storage_model_set        = false;
   bool is_soil_storage_model_depth_set  = false;
-  bool is_max_num_wetting_fronts_set    = false;
   bool is_water_table_depth_set         = false;
   bool is_water_table_based_method_set  = false;
   bool is_soil_moisture_fraction_depth_set        = false;
@@ -201,12 +200,6 @@ InitFromConfigFile(string config_file, struct soil_profile_parameters* parameter
       is_soil_storage_model_depth_set = true;
       continue;
     }
-    else if (param_key == "max_num_wetting_fronts") {
-      parameters->max_num_wetting_fronts =  stod(param_value);
-      assert (parameters->max_num_wetting_fronts > 0);
-      is_max_num_wetting_fronts_set = true;
-      continue;
-    }
     else if (param_key == "water_table_depth") {
       parameters->water_table_depth = stod(param_value);
       is_water_table_depth_set = true;
@@ -296,16 +289,12 @@ InitFromConfigFile(string config_file, struct soil_profile_parameters* parameter
       errMsg << "soil_moisture_profile_option_set key is not set in the config file "<< config_file << ", options = constant or linear \n";
       throw runtime_error(errMsg.str());
     }
-    
-    if (!is_max_num_wetting_fronts_set) {
-      parameters->max_num_wetting_fronts = 30;
-    }
 
     if (!is_water_table_depth_set) {
       parameters->water_table_depth = 6.0;
     }
     
-    assert (parameters->max_num_wetting_fronts > 0);
+    assert (parameters->num_wetting_fronts > 0);
     assert (parameters->water_table_depth >= 0);
   }
 

--- a/test/main_unittest.cxx
+++ b/test/main_unittest.cxx
@@ -492,6 +492,7 @@ int main(int argc, char *argv[])
   std::cout<<"| *************************************** \n";
   std::cout<<RESET<<"\n";
 
+  assert (passed == "Yes");
 
   //##########################################################################################################
   // Update the model for Conceptual soil reservoir's unitest
@@ -547,7 +548,8 @@ int main(int argc, char *argv[])
   std::cout<<"| *************************************** \n";
   std::cout<<RESET<<"\n";
 
-
+  assert (passed == "Yes");
+ 
   //##########################################################################################################
   // Test #2: four wetting fronts with only top wetting fully saturated; two wetting fronts in the top layer
   // benchmark values for Layered-based model with CONSTANT PROFILE OPTION
@@ -585,7 +587,8 @@ int main(int argc, char *argv[])
   std::cout<<"| Soil moisture fraction [-]: \n| Benchmark vs Computed | "<<soil_moisture_fraction_benchmark<<" vs "<<soil_moisture_fraction_computed<<"\n";
   std::cout<<"| *************************************** \n";
   std::cout<<RESET<<"\n";
-
+  
+  assert (passed == "Yes");
 
   //##########################################################################################################
   // Test #3: four wetting fronts with only top wetting fully saturated; two wetting fronts in the top layer
@@ -625,6 +628,64 @@ int main(int argc, char *argv[])
   std::cout<<"| Soil moisture fraction [-]: \n| Benchmark vs Computed | "<<soil_moisture_fraction_benchmark<<" vs "<<soil_moisture_fraction_computed<<"\n";
   std::cout<<"| *************************************** \n";
   std::cout<<RESET<<"\n";
+
+  assert (passed == "Yes");
+
+  //##########################################################################################################
+  // Test #4: calibratable parameters
+  {
+    std::cout<<GREEN<<"\n";
+    std::cout<<"| *************************************** \n";
+    std::cout<<"| Calibrated parameters test \n";
+    
+    model.Initialize(argv[1]);
+
+    double *smcmax_set, b_set, satpsi_set;
+    double *smcmax_get, b_get, satpsi_get;
+
+    smcmax_set = new double[1];
+    smcmax_get = new double[1];
+    
+    // Get initial values
+    model.GetValue("smcmax",&smcmax_set);
+    model.GetValue("b",&b_set);
+    model.GetValue("satpsi",&satpsi_set);
+
+    std::cout<<"| Initial values | smcmax = "<< smcmax_set[0] <<", b = "<< b_set <<", satpsi = "<< satpsi_set <<"\n";
+    
+    // set values
+    smcmax_set[0] += 0.012;
+    b_set += 0.013;
+    satpsi_set += 0.014;
+
+    std::cout<<"| Setting | smcmax = "<< smcmax_set[0] <<", b = "<< b_set <<", satpsi = "<< satpsi_set <<"\n";
+
+    model.SetValue("smcmax",&smcmax_set);
+    model.SetValue("b",&b_set);
+    model.SetValue("satpsi",&satpsi_set);
+
+    model.GetValue("smcmax", &smcmax_get);
+    model.GetValue("b", &b_get);
+    model.GetValue("satpsi", &satpsi_get);
+    
+    std::cout<<"| Getting | smcmax = "<< smcmax_get[0] <<", b = "<< b_get <<", satpsi = "<< satpsi_get <<"\n";
+    model.Update();
+    
+
+    test_status = fabs(smcmax_set[0] -  smcmax_get[0]) < 1.E-10 ? true : false;
+    test_status &= fabs(b_set - b_get) < 1.E-10 ? true : false;
+    test_status &= fabs(satpsi_set - satpsi_get) < 1.E-10 ? true : false;
+    
+    passed = test_status > 0 ? "Yes" : "No";
+
+   
+    std::cout<<"| Unittest passed : "<< RED << passed << RESET << GREEN <<"\n";
+    std::cout<<"| *************************************** \n";
+    std::cout<<RESET<<"\n";
+    
+    assert (passed == "Yes");
+  }  
+
   
   return FAILURE;
 }

--- a/test/main_unittest.cxx
+++ b/test/main_unittest.cxx
@@ -40,16 +40,16 @@ int main(int argc, char *argv[])
 
   std::cout<<"\n**************** TEST VALUES ************************************\n";
   int nz = 4;
-  bool test_status = true;
-  int num_input_vars = 8;
+  bool test_status    = true;
+  int num_input_vars  = 8;
   int num_output_vars = 3;
   
-  std::vector<string> bmi_input_vars = {"soil_storage", "soil_storage_change", "soil_moisture_wetting_fronts",
-					"soil_depth_wetting_fronts", "num_wetting_fronts", "Qb_topmodel", "Qv_topmodel",
-					"global_deficit"};
+  std::vector<string> bmi_input_vars = {"soil_storage", "soil_storage_change", "num_wetting_fronts",
+					"soil_moisture_wetting_fronts", "soil_depth_wetting_fronts",
+					"Qb_topmodel", "Qv_topmodel", "global_deficit"};
   std::vector<string> bmi_output_vars = {"soil_moisture_profile", "soil_water_table","soil_moisture_fraction"};
   
-  int nbytes_input[] = {sizeof(double), sizeof(double), sizeof(double), sizeof(double), sizeof(int),
+  int nbytes_input[] = {sizeof(double), sizeof(double), sizeof(int), sizeof(double), sizeof(double),
 			sizeof(double), sizeof(double), sizeof(double)};
   int nbytes_output[] = {int(nz * sizeof(double)), sizeof(double), sizeof(double)};
   //double soil_moisture_profile[] = {0.389,0.396,0.397,0.397}; // total_moisture_content
@@ -60,7 +60,7 @@ int main(int argc, char *argv[])
 
   std::cout<<"\nPulling information from BMI\n************************************\n";
   std::string model_name;
-  int count_in = 0;
+  int count_in  = 0;
   int count_out = 0;
   std::vector<std::string> names_in;
   std::vector<std::string> names_out;
@@ -406,11 +406,14 @@ int main(int argc, char *argv[])
       // get_value_at_indices to see if changed
       model.GetValueAtIndices(var_name, dest_new_up,  &indices[0], len);
       std::cout<<" Get value at indices: "<<dest_new_up[0]<<"\n";
+
       if (dest_new[0] == dest_new_up[0])
 	test_status &= true;
       else
 	test_status &= false;
-      
+
+      assert (test_status == true);
+
     }
 
   }
@@ -470,13 +473,14 @@ int main(int argc, char *argv[])
       
     }
     
+    assert (test_status == true);
       
   }
   
   passed = test_status > 0 ? "Yes" : "No";
   std::cout<<GREEN<<"\n";
   std::cout<<"| *************************************** \n";
-  std::cout<<"| All BMI Tests passed: "<< RED<< passed<<RESET<<GREEN<<"\n";
+  std::cout<<"| All BMI Tests passed: "<< RED << passed<<RESET<<GREEN<<"\n";
   std::cout<<"| *************************************** \n";
   std::cout<<RESET<<"\n";
 
@@ -647,10 +651,10 @@ int main(int argc, char *argv[])
     smcmax_get = new double[1];
     
     // Get initial values
-    model.GetValue("smcmax",&smcmax_set);
+    model.GetValue("smcmax",&smcmax_set[0]);
     model.GetValue("b",&b_set);
     model.GetValue("satpsi",&satpsi_set);
-
+    
     std::cout<<"| Initial values | smcmax = "<< smcmax_set[0] <<", b = "<< b_set <<", satpsi = "<< satpsi_set <<"\n";
     
     // set values
@@ -660,11 +664,11 @@ int main(int argc, char *argv[])
 
     std::cout<<"| Setting | smcmax = "<< smcmax_set[0] <<", b = "<< b_set <<", satpsi = "<< satpsi_set <<"\n";
 
-    model.SetValue("smcmax",&smcmax_set);
+    model.SetValue("smcmax",&smcmax_set[0]);
     model.SetValue("b",&b_set);
     model.SetValue("satpsi",&satpsi_set);
 
-    model.GetValue("smcmax", &smcmax_get);
+    model.GetValue("smcmax", &smcmax_get[0]);
     model.GetValue("b", &b_get);
     model.GetValue("satpsi", &satpsi_get);
     

--- a/test/main_unittest.cxx
+++ b/test/main_unittest.cxx
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
     return FAILURE;
   }
 
-  std::cout<<"\n**************** BEGIN SoilFreezeThaw BMI UNIT TEST *******************\n";
+  std::cout<<"\n**************** BEGIN SoilMoistureProfiles BMI UNIT TEST *******************\n";
   
   model.Initialize(argv[1]);
   model_layered.Initialize(argv[2]);


### PR DESCRIPTION
The PR adds calibratable parameters `smcmax` ,`b`, and `satpsi` to bmi output variables list. 

- The code has been tested in/out of nextgen, 
- Tested in active (on) and inactive (off) calibratable mode
- Existing tests have been updated
- No changes to the functionality
- Documentation (todo - as we plan to completely revise the Readme document of the repo)