### PR TITLE
accept short and long form of soil_params

### DIFF
--- a/src/soil_moisture_profile.cxx
+++ b/src/soil_moisture_profile.cxx
@@ -145,7 +145,8 @@ InitFromConfigFile(string config_file, struct soil_profile_parameters* parameter
       }
       continue;
     }
-    else if (param_key == "soil_params.smcmax") {
+	// NOTE: `soil_params.smcmax` may be deprecated in the future in favor of `smcmax`
+    else if (param_key == "smcmax" || param_key == "soil_params.smcmax") {
       if (param_value == "bmi" || param_value == "BMI") {
 	parameters->smcmax_bmi = true;
       }
@@ -164,13 +165,15 @@ InitFromConfigFile(string config_file, struct soil_profile_parameters* parameter
       
       continue;
     }
-    else if (param_key == "soil_params.b") {
+	// NOTE: `soil_params.b` may be deprecated in the future in favor of `b`
+    else if (param_key == "b" || param_key == "soil_params.b") {
       parameters->b = stod(param_value);
       assert (parameters->b > 0);
       is_b_set = true;
       continue;
     }
-    else if (param_key == "soil_params.satpsi") {
+	// NOTE: `soil_params.satpsi` may be deprecated in the future in favor of `satpsi`
+    else if (param_key == "satpsi" || param_key == "soil_params.satpsi") {
       parameters->satpsi = stod(param_value);
       is_satpsi_set = true;
       continue;


### PR DESCRIPTION
Currently, several NOAA-OWP maintained BMI modules (see https://github.com/NOAA-OWP/SoilFreezeThaw/pull/14#issuecomment-1864879127) share the convention of using `soil_params.<x>` where `x` is a parameter name in their config file format. However, when soil_params parameters are exposed as calibratable, the convention is to drop `soil_params` and just use the parameter name. To avoid confusion and increase consistency, this change enables specifying soil_params in SoilMoistureProfile config files using just their name. Support for the existing soil_params names is maintained.