### PR TITLE
ci: fix mac sed issue

### DIFF
--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -41,8 +41,7 @@ jobs:
         if [ ${{ runner.os }} == 'macOS' ]
         then
           brew install gnu-sed
-          #PATH="$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH"
-          PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
+          export PATH="$(brew --prefix gsed)/libexec/gnubin:$PATH"
         fi
           sed -i 's/\${CXX}/g++/' run_unittest.sh
           ./run_unittest.sh


### PR DESCRIPTION
`brew`'s prefix changes based if you are on apple arm vs intel x86. This generalizes how `gsed` is found as `sed` in `PATH` agnostic to architecture.