### PR TITLE
Update BMI C++ header to match upstream with virtual dtor

### DIFF
--- a/bmi/bmi.hxx
+++ b/bmi/bmi.hxx
@@ -6,13 +6,14 @@
 
 #ifndef BMI_HXX
 #define BMI_HXX
+
 #include <string>
 #include <vector>
 
-namespace bmixx {
+namespace bmi {
 
-  //const int BMI_SUCCESS = 0;
-  //  const int BMI_FAILURE = 1;
+  const int BMI_SUCCESS = 0;
+  const int BMI_FAILURE = 1;
 
   const int MAX_COMPONENT_NAME = 2048;
   const int MAX_VAR_NAME = 2048;
@@ -21,6 +22,8 @@ namespace bmixx {
 
   class Bmi {
     public:
+      virtual ~Bmi() { }
+
       // Model control functions.
       virtual void Initialize(std::string config_file) = 0;
       virtual void Update() = 0;

--- a/include/bmi_soil_moisture_profile.hxx
+++ b/include/bmi_soil_moisture_profile.hxx
@@ -16,7 +16,7 @@ namespace coupler {
 
 }
 
-class BmiSoilMoistureProfile : public bmixx::Bmi {
+class BmiSoilMoistureProfile : public bmi::Bmi {
 public:
   BmiSoilMoistureProfile() {
     this->input_var_names[0]  = "soil_storage";


### PR DESCRIPTION
Cf NOAA-OWP/ngen#831

These PRs need to be merged in tandem:
* NOAA-OWP/ngen#832
* NOAA-OWP/SLoTH#7
* https://github.com/NOAA-OWP/SoilMoistureProfiles/pull/17
* NOAA-OWP/SoilFreezeThaw#25
* NOAA-OWP/LGAR-C#26